### PR TITLE
feat: Add visibility toggle for server entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.project
 /.settings/
 /node_modules/
+*.zip

--- a/extension.js
+++ b/extension.js
@@ -39,13 +39,15 @@ export default class ServerStatusIndicatorExtension extends Extension {
 
         // panel items, one per server setting
         for (const savedSetting of this.savedSettings) {
-            const panel = new ServerStatusPanel(
-                savedSetting,
-                () => this.updateIcon(),
-                this.iconProvider,
-            );
-            this.serversBox.add_child(panel);
-            this.indicator.addStatusPanel(panel);
+            if (savedSetting.visible) {
+                const panel = new ServerStatusPanel(
+                    savedSetting,
+                    () => this.updateIcon(),
+                    this.iconProvider,
+                );
+                this.serversBox.add_child(panel);
+                this.indicator.addStatusPanel(panel);
+            }
         }
 
         // Open Prefs button
@@ -115,13 +117,15 @@ export default class ServerStatusIndicatorExtension extends Extension {
         this.savedSettings = SettingsParser.parseGioSettings(this.rawSettings);
         // recreate panel items, one per server setting
         for (const savedSetting of this.savedSettings) {
-            const panel = new ServerStatusPanel(
-                savedSetting,
-                () => this.updateIcon(),
-                this.iconProvider,
-            );
-            this.serversBox.add_child(panel);
-            this.indicator.addStatusPanel(panel);
+            if (savedSetting.visible) {
+                const panel = new ServerStatusPanel(
+                    savedSetting,
+                    () => this.updateIcon(),
+                    this.iconProvider,
+                );
+                this.serversBox.add_child(panel);
+                this.indicator.addStatusPanel(panel);
+            }
         }
         this.updateIcon();
     }

--- a/prefs.js
+++ b/prefs.js
@@ -180,6 +180,7 @@ export default class ServerStatusPreferences extends ExtensionPreferences {
                     settings.timeout = settings.timeout.toString();
                     settings.isGet = settings.isGet.toString();
                     settings.notifies = settings.notifies.toString();
+                    settings.visible = settings.visible.toString();
                     serverSettings.push(settings);
                 }
             }

--- a/schemas/org.gnome.shell.extensions.serverstatus.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.serverstatus.gschema.xml
@@ -4,9 +4,9 @@
 	<schema id="org.gnome.shell.extensions.serverstatus"
 		path="/org/gnome/shell/extensions/serverstatus/">
 		<key type="aa{ss}" name="server-settings">
-			<default>[{"name": "Footeware", "url": "https://footeware.ca", "frequency": "120", "timeout": "10", "isGet": "false", "notifies": "false"}]</default>
+			<default>[{"name": "Footeware", "url": "https://footeware.ca", "frequency": "120", "timeout": "10", "isGet": "false", "notifies": "false", "visible": "true"}]</default>
 			<summary>A list of server setting maps</summary>
-			<description>A list of {name, url, frequency, timeout, isGet, notifies} keys mapped to string values, one list entry per server panel.</description>
+			<description>A list of {name, url, frequency, timeout, isGet, notifies, visible} keys mapped to string values, one list entry per server panel.</description>
 		</key>
 	</schema>
 

--- a/serverGroup.js
+++ b/serverGroup.js
@@ -124,6 +124,23 @@ export class ServerGroup {
         moveRow.add_suffix(moveButtonBox);
         this.serverSettingGroup.add(moveRow);
 
+        // visibility row - show/hide server without deleting
+        this.visible = settings?.visible ?? true;
+        const visibilityRow = new Adw.ActionRow({
+            title: "Show in menu",
+            subtitle: "Hidden servers are not displayed and not checked",
+        });
+        const visibilityIcon = this.visible ? "view-reveal-symbolic" : "view-conceal-symbolic";
+        this.visibilityButton = Gtk.Button.new_from_icon_name(visibilityIcon);
+        this.visibilityButton.connect("clicked", () => {
+            this.visible = !this.visible;
+            const newIcon = this.visible ? "view-reveal-symbolic" : "view-conceal-symbolic";
+            this.visibilityButton.set_icon_name(newIcon);
+            this.update();
+        });
+        visibilityRow.add_suffix(this.visibilityButton);
+        this.serverSettingGroup.add(visibilityRow);
+
         // delete button
         const deleteRow = new Adw.ActionRow({
             title: "Delete this server",
@@ -309,6 +326,7 @@ export class ServerGroup {
             this.timeoutRow.text,
             this.useGetSwitchRow.active,
             this.useNotificationsSwitchRow.active,
+            this.visible,
         );
     }
 

--- a/serverGroup.js
+++ b/serverGroup.js
@@ -132,10 +132,19 @@ export class ServerGroup {
         });
         const visibilityIcon = this.visible ? "view-reveal-symbolic" : "view-conceal-symbolic";
         this.visibilityButton = Gtk.Button.new_from_icon_name(visibilityIcon);
+        const visibilityTooltip = this.visible
+            ? "Hide this server in the menu"
+            : "Show this server in the menu";
+        this.visibilityButton.set_tooltip_text(visibilityTooltip);
+        this.visibilityButton.set_accessible_name("Toggle server visibility in menu");
         this.visibilityButton.connect("clicked", () => {
             this.visible = !this.visible;
             const newIcon = this.visible ? "view-reveal-symbolic" : "view-conceal-symbolic";
+            const newTooltip = this.visible
+                ? "Hide this server in the menu"
+                : "Show this server in the menu";
             this.visibilityButton.set_icon_name(newIcon);
+            this.visibilityButton.set_tooltip_text(newTooltip);
             this.update();
         });
         visibilityRow.add_suffix(this.visibilityButton);

--- a/serverGroup.js
+++ b/serverGroup.js
@@ -132,19 +132,10 @@ export class ServerGroup {
         });
         const visibilityIcon = this.visible ? "view-reveal-symbolic" : "view-conceal-symbolic";
         this.visibilityButton = Gtk.Button.new_from_icon_name(visibilityIcon);
-        const visibilityTooltip = this.visible
-            ? "Hide this server in the menu"
-            : "Show this server in the menu";
-        this.visibilityButton.set_tooltip_text(visibilityTooltip);
-        this.visibilityButton.set_accessible_name("Toggle server visibility in menu");
         this.visibilityButton.connect("clicked", () => {
             this.visible = !this.visible;
             const newIcon = this.visible ? "view-reveal-symbolic" : "view-conceal-symbolic";
-            const newTooltip = this.visible
-                ? "Hide this server in the menu"
-                : "Show this server in the menu";
             this.visibilityButton.set_icon_name(newIcon);
-            this.visibilityButton.set_tooltip_text(newTooltip);
             this.update();
         });
         visibilityRow.add_suffix(this.visibilityButton);

--- a/serverSetting.js
+++ b/serverSetting.js
@@ -13,13 +13,15 @@ export class ServerSetting {
      * @param {Number} timeout
      * @param {boolean} isGet
      * @param {boolean} notifies
+     * @param {boolean} visible
      */
-    constructor(name, url, frequency, timeout, isGet, notifies) {
+    constructor(name, url, frequency, timeout, isGet, notifies, visible = true) {
         this.name = name;
         this.url = url;
         this.frequency = frequency;
         this.timeout = timeout;
         this.isGet = isGet;
         this.notifies = notifies;
+        this.visible = visible;
     }
 }

--- a/settingsParser.js
+++ b/settingsParser.js
@@ -39,8 +39,9 @@ export class SettingsParser {
             }
 
             const notifies = savedSetting["notifies"] !== undefined ? savedSetting["notifies"] === "true" : false; // defaults to false
+            const visible = savedSetting["visible"] !== undefined ? savedSetting["visible"] === "true" : true; // defaults to true for backward compatibility
 
-            const setting = new ServerSetting(name, url, frequency, timeout, isGet, notifies);
+            const setting = new ServerSetting(name, url, frequency, timeout, isGet, notifies, visible);
             settings.push(setting);
         }
         return settings;


### PR DESCRIPTION
## Screenshots

### Hide a server
`hide`

<img width="1107" height="1080" alt="截图 2026-03-29 09-48-01" src="https://github.com/user-attachments/assets/b1386629-9cfc-4296-b5cc-c0f0972a74b5" />

### Show a server
`show`

<img width="1107" height="1080" alt="截图 2026-03-29 09-48-08" src="https://github.com/user-attachments/assets/d927c2b9-b061-429e-a87f-b13f6eda8996" />

## Usage

- Click the eye icon in server settings to toggle visibility
- Hidden servers are skipped during status checks and don't appear in the GNOME shell panel
- Useful for keeping configuration of servers you don't always need to monitor

